### PR TITLE
fix: 変数の出力方法の問題で環境によってエラーが起きることを解決

### DIFF
--- a/Hook.php
+++ b/Hook.php
@@ -42,7 +42,7 @@ class Hook
 
         $secret = $config->get('google_recaptcha_secret');
         $response = $thisModule->Post->get('g-recaptcha-token');
-        $api = $this->endpoint . "?secret=${secret}&response=${response}";
+        $api = $this->endpoint . "?secret={$secret}&response={$response}";
         $valid = false;
 
         try {


### PR DESCRIPTION
PHPでは `${var}` と `{$var}` ともに利用できるみたいですが、php.iniでの設定や、PHPのバージョンによって`${var}`が使えないケースがあるようです。ですので、`{$var}`に変更しました。